### PR TITLE
chore: delete symbols from libraw23.symbols

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libraw (0.21.1-7deepin1) unstable; urgency=medium
+
+  * delete symbols from libraw23.symlbols
+
+ -- bluesky <chenchongbiao@deepin.org>  Mon, 25 Sep 2023 13:59:40 +0800
+
 libraw (0.21.1-7) unstable; urgency=medium
 
   * debian/libraw23.symbols: more symbols fixing

--- a/debian/libraw23.symbols
+++ b/debian/libraw23.symbols
@@ -444,12 +444,6 @@ libraw.so.23 libraw23 #MINVER#
  (c++|arch-bits=32)"std::vector<char, std::allocator<char> >::_M_default_append(unsigned int)@Base" 0.21.1
  (c++|arch-bits=32)"std::vector<unsigned int, std::allocator<unsigned int> >::~vector()@Base" 0.21.1
  (c++|arch-bits=32)"std::vector<unsigned int, std::allocator<unsigned int> >::~vector()@Base" 0.21.1
- (c++)"libraw_static_table_t::operator[](unsigned int) const@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<char, std::allocator<char> >::_M_default_append(unsigned long)@Base" 0.21.1
- (c++)"std::vector<unsigned char, std::allocator<unsigned char> >::~vector()@Base" 0.21.1
- (c++)"std::vector<unsigned char, std::allocator<unsigned char> >::~vector()@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<unsigned long, std::allocator<unsigned long> >::~vector()@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<unsigned long, std::allocator<unsigned long> >::~vector()@Base" 0.21.1
  (c++)"pana_cs6_page_decoder::read_page()@Base" 0.20.0
  (c++)"LibRaw_abstract_datastream::buffering_off()@Base" 0.20.0
  (c++)"LibRaw::aRGB_coeff(double (*) [3])@Base" 0.20.0
@@ -1077,12 +1071,6 @@ libraw_r.so.23 libraw23 #MINVER#
  (c++|arch-bits=32)"std::vector<char, std::allocator<char> >::_M_default_append(unsigned int)@Base" 0.21.1
  (c++|arch-bits=32)"std::vector<unsigned int, std::allocator<unsigned int> >::~vector()@Base" 0.21.1
  (c++|arch-bits=32)"std::vector<unsigned int, std::allocator<unsigned int> >::~vector()@Base" 0.21.1
- (c++)"libraw_static_table_t::operator[](unsigned int) const@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<char, std::allocator<char> >::_M_default_append(unsigned long)@Base" 0.21.1
- (c++)"std::vector<unsigned char, std::allocator<unsigned char> >::~vector()@Base" 0.21.1
- (c++)"std::vector<unsigned char, std::allocator<unsigned char> >::~vector()@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<unsigned long, std::allocator<unsigned long> >::~vector()@Base" 0.21.1
- (c++|arch-bits=64)"std::vector<unsigned long, std::allocator<unsigned long> >::~vector()@Base" 0.21.1
  (c++)"pana_cs6_page_decoder::read_page()@Base" 0.20.0
  q_step_tbl@Base 0.21.1
  (c++)"LibRaw_abstract_datastream::buffering_off()@Base" 0.20.0


### PR DESCRIPTION
目前源里的 g++ 版本为12,使用当前版本编译导致缺少 symbols 符号而无法生成 deb 包，目前先删除，等 g++ 版本升为13后修改回来。

Log: delete symbols
Issue: https://github.com/linuxdeepin/developer-center/issues/5731